### PR TITLE
Cache parsed signing key for performance

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -61,7 +61,8 @@ var _ = gc.Suite(&AuthSuite{})
 func (s *AuthSuite) TestCreateSdcAuthorizationHeader(c *gc.C) {
 	headers := make(http.Header)
 	headers["Date"] = []string{"Mon, 14 Oct 2013 18:49:29 GMT"}
-	authentication := auth.Auth{User: "test_user", PrivateKey: key, Algorithm: "rsa-sha256"}
+	authentication, err := auth.NewAuth("test_user", key, "rsa-sha256")
+	c.Assert(err, gc.IsNil)
 	credentials := &auth.Credentials{
 		UserAuthentication: authentication,
 		SdcKeyId:           "test_key",
@@ -75,7 +76,8 @@ func (s *AuthSuite) TestCreateSdcAuthorizationHeader(c *gc.C) {
 func (s *AuthSuite) TestCreateMantaAuthorizationHeader(c *gc.C) {
 	headers := make(http.Header)
 	headers["Date"] = []string{"Mon, 14 Oct 2013 18:49:29 GMT"}
-	authentication := auth.Auth{User: "test_user", PrivateKey: key, Algorithm: "rsa-sha256"}
+	authentication, err := auth.NewAuth("test_user", key, "rsa-sha256")
+	c.Assert(err, gc.IsNil)
 	credentials := &auth.Credentials{
 		UserAuthentication: authentication,
 		MantaKeyId:         "test_key",


### PR DESCRIPTION
When an Auth is constructed, parse the private key data once. Then reuse the parsed data whenever a signature is required. This saves a lot of CPU.
