### PR TITLE
Update gosign.go with current license info

### DIFF
--- a/gosign.go
+++ b/gosign.go
@@ -6,7 +6,7 @@ The sign package is structured as follow:
 
 	- gosign/auth. This package deals with the authorization and signature of requests.
 
-Licensed under LGPL v3.
+Licensed under Mozilla Public License Version 2.0.
 
 Copyright (c) 2013 Joyent Inc.
 Written by Daniele Stroppa <daniele.stroppa@joyent.com>


### PR DESCRIPTION
As pointed out by @lloydde in https://github.com/hashicorp/terraform/pull/5277#issuecomment-198858361

Should have gone with https://github.com/joyent/gosign/pull/5 to address:

- https://github.com/joyent/gosign/issues/4
- https://github.com/hashicorp/terraform/pull/5277#issuecomment-198758723
